### PR TITLE
Remove multi-threaded reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.17
+
+- Remove multi-threaded parsing. It was a bad idea. Performance is better without it. Code is simpler.
+
 ## 0.3.16
 
 - Optimize hash construction by interning key strings

--- a/ext/osv/src/csv/mod.rs
+++ b/ext/osv/src/csv/mod.rs
@@ -8,6 +8,6 @@ mod ruby_reader;
 
 pub use builder::RecordReaderBuilder;
 pub use header_cache::StringCacheKey;
-pub use record::CowValue;
+pub use record::CowStr;
 pub use record::CsvRecord;
 pub use ruby_integration::*;

--- a/ext/osv/src/csv/mod.rs
+++ b/ext/osv/src/csv/mod.rs
@@ -7,7 +7,6 @@ mod ruby_integration;
 mod ruby_reader;
 
 pub use builder::RecordReaderBuilder;
-pub(crate) use builder::BUFFER_CHANNEL_SIZE;
 pub use header_cache::StringCacheKey;
 pub use record::CowValue;
 pub use record::CsvRecord;

--- a/ext/osv/src/csv/parser.rs
+++ b/ext/osv/src/csv/parser.rs
@@ -11,7 +11,7 @@ pub trait RecordParser<'a> {
     fn parse(
         headers: &[StringCacheKey],
         record: &csv::StringRecord,
-        null_string: Option<&str>,
+        null_string: Option<&'a str>,
         flexible_default: Option<Cow<'a, str>>,
     ) -> Self::Output;
 }
@@ -86,67 +86,3 @@ impl<'a> RecordParser<'a> for Vec<Option<CowValue<'a>>> {
         vec
     }
 }
-
-// impl<'a, S: BuildHasher + Default + 'a> RecordParser<'a>
-//     for HashMap<&'static str, Option<String>, S>
-// {
-//     type Output = Self;
-
-//     #[inline]
-//     fn parse(
-//         headers: &[&'static str],
-//         record: &csv::StringRecord,
-//         null_string: Option<&str>,
-//         flexible_default: Option<Cow<'a, str>>,
-//     ) -> Self::Output {
-//         let mut map = HashMap::with_capacity_and_hasher(headers.len(), S::default());
-//         headers.iter().enumerate().for_each(|(i, &header)| {
-//             let value = record.get(i).map_or_else(
-//                 || flexible_default.clone(),
-//                 |field| {
-//                     if null_string == Some(field) {
-//                         None
-//                     } else if field.is_empty() {
-//                         Some(String::new())
-//                     } else {
-//                         Some(field.into())
-//                     }
-//                 },
-//             );
-//             map.insert(header, value);
-//         });
-//         map
-//     }
-// }
-
-// impl<'a> RecordParser<'a> for Vec<Option<String>> {
-//     type Output = Self;
-
-//     #[inline]
-//     fn parse(
-//         headers: &[&'static str],
-//         record: &csv::StringRecord,
-//         null_string: Option<&str>,
-//         flexible_default: Option<Cow<'a, str>>,
-//     ) -> Self::Output {
-//         let target_len = headers.len();
-//         let mut vec = Vec::with_capacity(target_len);
-//         for field in record.iter() {
-//             let value = if Some(field) == null_string {
-//                 None
-//             } else if field.is_empty() {
-//                 Some(String::new())
-//             } else {
-//                 Some(field.into())
-//             };
-//             vec.push(value);
-//         }
-
-//         if vec.len() < target_len {
-//             if let Some(default) = flexible_default {
-//                 vec.resize_with(target_len, || Some(default.to_string()));
-//             }
-//         }
-//         vec
-//     }
-// }

--- a/ext/osv/src/csv/record.rs
+++ b/ext/osv/src/csv/record.rs
@@ -6,8 +6,8 @@ use super::StringCacheKey;
 
 #[derive(Debug)]
 pub enum CsvRecord<'a, S: BuildHasher + Default> {
-    Vec(Vec<Option<CowValue<'a>>>),
-    Map(HashMap<StringCacheKey, Option<CowValue<'a>>, S>),
+    Vec(Vec<Option<CowStr<'a>>>),
+    Map(HashMap<StringCacheKey, Option<CowStr<'a>>, S>),
 }
 
 impl<S: BuildHasher + Default> IntoValue for CsvRecord<'_, S> {
@@ -46,9 +46,9 @@ impl<S: BuildHasher + Default> IntoValue for CsvRecord<'_, S> {
 }
 
 #[derive(Debug, Clone)]
-pub struct CowValue<'a>(pub Cow<'a, str>);
+pub struct CowStr<'a>(pub Cow<'a, str>);
 
-impl IntoValue for CowValue<'_> {
+impl IntoValue for CowStr<'_> {
     fn into_value_with(self, handle: &Ruby) -> Value {
         self.0.into_value_with(handle)
     }

--- a/ext/osv/src/csv/record_reader.rs
+++ b/ext/osv/src/csv/record_reader.rs
@@ -2,29 +2,20 @@ use super::header_cache::StringCacheKey;
 use super::parser::RecordParser;
 use super::{header_cache::StringCache, ruby_reader::SeekableRead};
 use magnus::{Error, Ruby};
+use std::borrow::Cow;
 use std::io::BufReader;
-use std::{borrow::Cow, io::Read, thread};
+use std::io::Read;
+use std::marker::PhantomData;
 
 pub(crate) const READ_BUFFER_SIZE: usize = 16384;
 
 pub struct RecordReader<'a, T: RecordParser<'a>> {
-    inner: ReaderImpl<'a, T>,
-}
-
-#[allow(clippy::large_enum_variant)]
-enum ReaderImpl<'a, T: RecordParser<'a>> {
-    SingleThreaded {
-        reader: csv::Reader<BufReader<Box<dyn SeekableRead>>>,
-        headers: Vec<StringCacheKey>,
-        null_string: Option<String>,
-        flexible_default: Option<Cow<'a, str>>,
-        string_record: csv::StringRecord,
-    },
-    MultiThreaded {
-        headers: Vec<StringCacheKey>,
-        receiver: kanal::Receiver<T::Output>,
-        handle: Option<thread::JoinHandle<()>>,
-    },
+    reader: csv::Reader<BufReader<Box<dyn SeekableRead>>>,
+    headers: Vec<StringCacheKey>,
+    null_string: Option<String>,
+    flexible_default: Option<Cow<'a, str>>,
+    string_record: csv::StringRecord,
+    _phantom: PhantomData<T>,
 }
 
 impl<'a, T: RecordParser<'a>> RecordReader<'a, T> {
@@ -50,7 +41,7 @@ impl<'a, T: RecordParser<'a>> RecordReader<'a, T> {
         Ok(headers)
     }
 
-    pub(crate) fn new_single_threaded(
+    pub(crate) fn new(
         reader: csv::Reader<BufReader<Box<dyn SeekableRead>>>,
         headers: Vec<StringCacheKey>,
         null_string: Option<String>,
@@ -58,50 +49,12 @@ impl<'a, T: RecordParser<'a>> RecordReader<'a, T> {
     ) -> Self {
         let headers_len = headers.len();
         Self {
-            inner: ReaderImpl::SingleThreaded {
-                reader,
-                headers,
-                null_string,
-                flexible_default: flexible_default.map(Cow::Borrowed),
-                string_record: csv::StringRecord::with_capacity(READ_BUFFER_SIZE, headers_len),
-            },
-        }
-    }
-}
-
-impl<T: RecordParser<'static> + Send> RecordReader<'static, T> {
-    pub(crate) fn new_multi_threaded(
-        mut reader: csv::Reader<Box<dyn Read + Send + 'static>>,
-        headers: Vec<StringCacheKey>,
-        buffer_size: usize,
-        null_string: Option<String>,
-        flexible_default: Option<&'static str>,
-    ) -> Self {
-        let (sender, receiver) = kanal::bounded(buffer_size);
-        let headers_for_thread = headers.clone();
-
-        let handle = thread::spawn(move || {
-            let mut record =
-                csv::StringRecord::with_capacity(READ_BUFFER_SIZE, headers_for_thread.len());
-            while let Ok(true) = reader.read_record(&mut record) {
-                let row = T::parse(
-                    &headers_for_thread,
-                    &record,
-                    null_string.as_deref(),
-                    flexible_default.map(Cow::Borrowed),
-                );
-                if sender.send(row).is_err() {
-                    break;
-                }
-            }
-        });
-
-        Self {
-            inner: ReaderImpl::MultiThreaded {
-                headers,
-                receiver,
-                handle: Some(handle),
-            },
+            reader,
+            headers,
+            null_string,
+            flexible_default: flexible_default.map(Cow::Borrowed),
+            string_record: csv::StringRecord::with_capacity(READ_BUFFER_SIZE, headers_len),
+            _phantom: PhantomData,
         }
     }
 }
@@ -111,34 +64,15 @@ impl<'a, T: RecordParser<'a>> Iterator for RecordReader<'a, T> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.inner {
-            ReaderImpl::MultiThreaded {
-                receiver, handle, ..
-            } => match receiver.recv() {
-                Ok(record) => Some(record),
-                Err(_) => {
-                    if let Some(handle) = handle.take() {
-                        let _ = handle.join();
-                    }
-                    None
-                }
-            },
-            ReaderImpl::SingleThreaded {
-                reader,
-                headers,
-                null_string,
-                flexible_default,
-                ref mut string_record,
-            } => match reader.read_record(string_record) {
-                Ok(true) => Some(T::parse(
-                    headers,
-                    string_record,
-                    null_string.as_deref(),
-                    flexible_default.clone(),
-                )),
-                Ok(false) => None,
-                Err(_e) => None,
-            },
+        match self.reader.read_record(&mut self.string_record) {
+            Ok(true) => Some(T::parse(
+                &self.headers,
+                &self.string_record,
+                self.null_string.as_deref(),
+                self.flexible_default.clone(),
+            )),
+            Ok(false) => None,
+            Err(_e) => None,
         }
     }
 
@@ -152,22 +86,6 @@ impl<'a, T: RecordParser<'a>> Iterator for RecordReader<'a, T> {
 impl<'a, T: RecordParser<'a>> Drop for RecordReader<'a, T> {
     #[inline]
     fn drop(&mut self) {
-        match &mut self.inner {
-            ReaderImpl::MultiThreaded {
-                receiver,
-                handle,
-                headers,
-                ..
-            } => {
-                receiver.close();
-                if let Some(handle) = handle.take() {
-                    let _ = handle.join();
-                }
-                let _ = StringCache::clear(&headers);
-            }
-            ReaderImpl::SingleThreaded { headers, .. } => {
-                let _ = StringCache::clear(&headers);
-            }
-        }
+        let _ = StringCache::clear(&self.headers);
     }
 }

--- a/ext/osv/src/csv/record_reader.rs
+++ b/ext/osv/src/csv/record_reader.rs
@@ -14,7 +14,7 @@ pub struct RecordReader<T: RecordParser<'static>> {
     reader: csv::Reader<BufReader<Box<dyn SeekableRead>>>,
     headers: Vec<StringCacheKey>,
     null_string: Option<&'static str>,
-    flexible_default: Option<String>,
+    flexible_default: Option<&'static str>,
     string_record: csv::StringRecord,
     parser: std::marker::PhantomData<T>,
 }
@@ -54,7 +54,7 @@ impl<T: RecordParser<'static>> RecordReader<T> {
         reader: csv::Reader<BufReader<Box<dyn SeekableRead>>>,
         headers: Vec<StringCacheKey>,
         null_string: Option<&'static str>,
-        flexible_default: Option<String>,
+        flexible_default: Option<&'static str>,
     ) -> Self {
         let headers_len = headers.len();
         Self {
@@ -74,9 +74,7 @@ impl<T: RecordParser<'static>> RecordReader<T> {
                 &self.headers,
                 &self.string_record,
                 self.null_string,
-                self.flexible_default
-                    .as_ref()
-                    .map(|s| std::borrow::Cow::Owned(s.clone())),
+                self.flexible_default.map(|s| std::borrow::Cow::Borrowed(s)),
             ))),
             false => Ok(None),
         }

--- a/ext/osv/src/csv/ruby_integration.rs
+++ b/ext/osv/src/csv/ruby_integration.rs
@@ -1,30 +1,19 @@
-use std::{fs::File, io, mem::ManuallyDrop};
+use std::{
+    fs::File,
+    io::{self, Read, Seek, SeekFrom},
+    mem::ManuallyDrop,
+};
 
 pub struct ForgottenFileHandle(pub ManuallyDrop<File>);
 
-impl std::io::Read for ForgottenFileHandle {
+impl Read for ForgottenFileHandle {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
     }
+}
 
-    fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> io::Result<usize> {
-        self.0.read_vectored(bufs)
-    }
-
-    // fn read_buf(&mut self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
-    //     self.0.read_buf(cursor)
-    // }
-
-    // #[inline]
-    // fn is_read_vectored(&self) -> bool {
-    //     self.0.is_read_vectored()
-    // }
-
-    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        self.0.read_to_end(buf)
-    }
-
-    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
-        self.0.read_to_string(buf)
+impl Seek for ForgottenFileHandle {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.0.seek(pos)
     }
 }

--- a/ext/osv/src/csv/ruby_reader.rs
+++ b/ext/osv/src/csv/ruby_reader.rs
@@ -2,7 +2,8 @@ use magnus::{
     value::{Opaque, ReprValue},
     RClass, RString, Ruby, Value,
 };
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek, SeekFrom, Write};
 use std::sync::OnceLock;
 
 static STRING_IO_CLASS: OnceLock<Opaque<RClass>> = OnceLock::new();
@@ -17,6 +18,8 @@ pub struct RubyReader<T> {
 pub trait SeekableRead: std::io::Read + Seek {}
 impl SeekableRead for RubyReader<Value> {}
 impl SeekableRead for RubyReader<RString> {}
+impl SeekableRead for File {}
+impl<T: Read + Seek> SeekableRead for BufReader<T> {}
 
 pub fn build_ruby_reader(
     ruby: &Ruby,

--- a/ext/osv/src/csv/ruby_reader.rs
+++ b/ext/osv/src/csv/ruby_reader.rs
@@ -6,6 +6,8 @@ use std::fs::File;
 use std::io::{self, BufReader, Read, Seek, SeekFrom, Write};
 use std::sync::OnceLock;
 
+use super::ForgottenFileHandle;
+
 static STRING_IO_CLASS: OnceLock<Opaque<RClass>> = OnceLock::new();
 
 /// A reader that can handle various Ruby input types (String, StringIO, IO-like objects)
@@ -20,6 +22,8 @@ impl SeekableRead for RubyReader<Value> {}
 impl SeekableRead for RubyReader<RString> {}
 impl SeekableRead for File {}
 impl<T: Read + Seek> SeekableRead for BufReader<T> {}
+impl SeekableRead for std::io::Cursor<Vec<u8>> {}
+impl SeekableRead for ForgottenFileHandle {}
 
 pub fn build_ruby_reader(
     ruby: &Ruby,

--- a/ext/osv/src/reader.rs
+++ b/ext/osv/src/reader.rs
@@ -1,4 +1,4 @@
-use crate::csv::{CowValue, CsvRecord, RecordReaderBuilder, StringCacheKey};
+use crate::csv::{CowStr, CsvRecord, RecordReaderBuilder, StringCacheKey};
 use crate::utils::*;
 use ahash::RandomState;
 use csv::Trim;
@@ -92,7 +92,7 @@ pub fn parse_csv(
     let iter: Box<dyn Iterator<Item = CsvRecord<RandomState>>> = match result_type {
         ResultType::Hash => {
             let builder = RecordReaderBuilder::<
-                HashMap<StringCacheKey, Option<CowValue<'static>>, RandomState>,
+                HashMap<StringCacheKey, Option<CowStr<'static>>, RandomState>,
             >::new(ruby, to_read)
             .has_headers(has_headers)
             .flexible(flexible)
@@ -105,7 +105,7 @@ pub fn parse_csv(
             Box::new(builder.build()?.map(CsvRecord::Map))
         }
         ResultType::Array => {
-            let builder = RecordReaderBuilder::<Vec<Option<CowValue<'static>>>>::new(ruby, to_read)
+            let builder = RecordReaderBuilder::<Vec<Option<CowStr<'static>>>>::new(ruby, to_read)
                 .has_headers(has_headers)
                 .flexible(flexible)
                 .flexible_default(flexible_default)

--- a/ext/osv/src/reader.rs
+++ b/ext/osv/src/reader.rs
@@ -6,88 +6,25 @@ use magnus::value::ReprValue;
 use magnus::{block::Yield, Error, KwArgs, RHash, Ruby, Symbol, Value};
 use std::collections::HashMap;
 
-pub fn parse_csv(
-    rb_self: Value,
-    args: &[Value],
-) -> Result<Yield<Box<dyn Iterator<Item = CsvRecord<'static, RandomState>>>>, Error> {
-    let original = unsafe { Ruby::get_unchecked() };
-    let ruby: &'static Ruby = Box::leak(Box::new(original));
-
-    let ReadCsvArgs {
-        to_read,
-        has_headers,
-        delimiter,
-        quote_char,
-        null_string,
-        result_type,
-        flexible,
-        flexible_default,
-        trim,
-    } = parse_read_csv_args(ruby, args)?;
-
-    let flexible_default: &'static Option<String> = Box::leak(Box::new(flexible_default));
-    let leaked_flexible_default: &'static Option<&str> =
-        Box::leak(Box::new(flexible_default.as_deref()));
-
-    if !ruby.block_given() {
-        return create_enumerator(EnumeratorArgs {
-            rb_self,
-            to_read,
-            has_headers,
-            delimiter,
-            quote_char,
-            null_string,
-            buffer_size: 0,
-            result_type,
-            flexible,
-            flexible_default: leaked_flexible_default.as_deref(),
-            trim: match trim {
-                Trim::All => Some("all".to_string()),
-                Trim::Headers => Some("headers".to_string()),
-                Trim::Fields => Some("fields".to_string()),
-                _ => None,
-            },
-        });
-    }
-
-    let iter: Box<dyn Iterator<Item = CsvRecord<RandomState>>> = match result_type.as_str() {
-        "hash" => {
-            let builder = RecordReaderBuilder::<
-                HashMap<StringCacheKey, Option<CowValue<'static>>, RandomState>,
-            >::new(ruby, to_read)
-            .has_headers(has_headers)
-            .flexible(flexible)
-            .flexible_default(flexible_default.as_deref())
-            .trim(trim)
-            .delimiter(delimiter)
-            .quote_char(quote_char)
-            .null_string(null_string);
-
-            Box::new(builder.build()?.map(CsvRecord::Map))
-        }
-        "array" => Box::new(
-            RecordReaderBuilder::<Vec<Option<CowValue<'static>>>>::new(ruby, to_read)
-                .has_headers(has_headers)
-                .flexible(flexible)
-                .flexible_default(flexible_default.as_deref())
-                .trim(trim)
-                .delimiter(delimiter)
-                .quote_char(quote_char)
-                .null_string(null_string)
-                .build()?
-                .map(CsvRecord::Vec),
-        ),
-        _ => {
-            return Err(Error::new(
-                ruby.exception_runtime_error(),
-                "Invalid result type",
-            ))
-        }
-    };
-
-    Ok(Yield::Iter(iter))
+/// Valid result types for CSV parsing
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResultType {
+    Hash,
+    Array,
 }
 
+impl ResultType {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "hash" => Some(Self::Hash),
+            "array" => Some(Self::Array),
+            _ => None,
+        }
+    }
+}
+
+/// Arguments for creating an enumerator
+#[derive(Debug)]
 struct EnumeratorArgs {
     rb_self: Value,
     to_read: Value,
@@ -102,6 +39,100 @@ struct EnumeratorArgs {
     trim: Option<String>,
 }
 
+/// Parses a CSV file with the given configuration.
+///
+/// # Safety
+/// This function uses unsafe code to get the Ruby runtime and leak memory for static references.
+/// This is necessary for Ruby integration but should be used with caution.
+pub fn parse_csv(
+    rb_self: Value,
+    args: &[Value],
+) -> Result<Yield<Box<dyn Iterator<Item = CsvRecord<'static, RandomState>>>>, Error> {
+    // SAFETY: We're in a Ruby callback, so Ruby runtime is guaranteed to be initialized
+    let ruby = unsafe { Ruby::get_unchecked() };
+
+    let ReadCsvArgs {
+        to_read,
+        has_headers,
+        delimiter,
+        quote_char,
+        null_string,
+        result_type,
+        flexible,
+        flexible_default,
+        trim,
+    } = parse_read_csv_args(&ruby, args)?;
+
+    // Convert flexible_default to static lifetime
+    // SAFETY: This memory is intentionally leaked as it needs to live for the duration of the Ruby process
+    let flexible_default = Box::leak(Box::new(flexible_default));
+
+    if !ruby.block_given() {
+        return create_enumerator(EnumeratorArgs {
+            rb_self,
+            to_read,
+            has_headers,
+            delimiter,
+            quote_char,
+            null_string,
+            buffer_size: 0,
+            result_type: result_type.clone(),
+            flexible,
+            flexible_default: flexible_default.as_deref(),
+            trim: match trim {
+                Trim::All => Some("all".to_string()),
+                Trim::Headers => Some("headers".to_string()),
+                Trim::Fields => Some("fields".to_string()),
+                _ => None,
+            },
+        });
+    }
+
+    // Convert null_string to static lifetime if present
+    // SAFETY: This memory is intentionally leaked as it needs to live for the duration of the Ruby process
+    let null_string = null_string.map(|s| Box::leak(Box::new(s)) as &'static str);
+
+    let result_type = ResultType::from_str(&result_type).ok_or_else(|| {
+        Error::new(
+            ruby.exception_runtime_error(),
+            "Invalid result type, expected 'hash' or 'array'",
+        )
+    })?;
+
+    let iter: Box<dyn Iterator<Item = CsvRecord<RandomState>>> = match result_type {
+        ResultType::Hash => {
+            let builder = RecordReaderBuilder::<
+                HashMap<StringCacheKey, Option<CowValue<'static>>, RandomState>,
+            >::new(ruby, to_read)
+            .has_headers(has_headers)
+            .flexible(flexible)
+            .flexible_default(flexible_default.clone())
+            .trim(trim)
+            .delimiter(delimiter)
+            .quote_char(quote_char)
+            .null_string(null_string);
+
+            Box::new(builder.build()?.map(CsvRecord::Map))
+        }
+        ResultType::Array => {
+            let builder = RecordReaderBuilder::<Vec<Option<CowValue<'static>>>>::new(ruby, to_read)
+                .has_headers(has_headers)
+                .flexible(flexible)
+                .flexible_default(flexible_default.clone())
+                .trim(trim)
+                .delimiter(delimiter)
+                .quote_char(quote_char)
+                .null_string(null_string)
+                .build()?;
+
+            Box::new(builder.map(CsvRecord::Vec))
+        }
+    };
+
+    Ok(Yield::Iter(iter))
+}
+
+/// Creates an enumerator for lazy CSV parsing
 fn create_enumerator(
     args: EnumeratorArgs,
 ) -> Result<Yield<Box<dyn Iterator<Item = CsvRecord<'static, RandomState>>>>, Error> {
@@ -121,6 +152,7 @@ fn create_enumerator(
     kwargs.aset(Symbol::new("flexible"), args.flexible)?;
     kwargs.aset(Symbol::new("flexible_default"), args.flexible_default)?;
     kwargs.aset(Symbol::new("trim"), args.trim.map(Symbol::new))?;
+
     let enumerator = args
         .rb_self
         .enumeratorize("for_each", (args.to_read, KwArgs(kwargs)));

--- a/ext/osv/src/reader.rs
+++ b/ext/osv/src/reader.rs
@@ -19,7 +19,6 @@ pub fn parse_csv(
         delimiter,
         quote_char,
         null_string,
-        buffer_size,
         result_type,
         flexible,
         flexible_default,
@@ -38,7 +37,7 @@ pub fn parse_csv(
             delimiter,
             quote_char,
             null_string,
-            buffer_size,
+            buffer_size: 0,
             result_type,
             flexible,
             flexible_default: leaked_flexible_default.as_deref(),
@@ -62,10 +61,9 @@ pub fn parse_csv(
             .trim(trim)
             .delimiter(delimiter)
             .quote_char(quote_char)
-            .null_string(null_string)
-            .buffer(buffer_size);
+            .null_string(null_string);
 
-            Box::new(builder.build_threaded()?.map(CsvRecord::Map))
+            Box::new(builder.build()?.map(CsvRecord::Map))
         }
         "array" => Box::new(
             RecordReaderBuilder::<Vec<Option<CowValue<'static>>>>::new(ruby, to_read)
@@ -76,8 +74,7 @@ pub fn parse_csv(
                 .delimiter(delimiter)
                 .quote_char(quote_char)
                 .null_string(null_string)
-                .buffer(buffer_size)
-                .build_threaded()?
+                .build()?
                 .map(CsvRecord::Vec),
         ),
         _ => {

--- a/ext/osv/src/utils.rs
+++ b/ext/osv/src/utils.rs
@@ -4,8 +4,6 @@ use magnus::{
     Error, RString, Ruby, Symbol, Value,
 };
 
-use crate::csv::BUFFER_CHANNEL_SIZE;
-
 fn parse_string_or_symbol(ruby: &Ruby, value: Value) -> Result<Option<String>, Error> {
     if value.is_nil() {
         Ok(None)
@@ -34,7 +32,6 @@ pub struct ReadCsvArgs {
     pub delimiter: u8,
     pub quote_char: u8,
     pub null_string: Option<String>,
-    pub buffer_size: usize,
     pub result_type: String,
     pub flexible: bool,
     pub flexible_default: Option<String>,
@@ -107,7 +104,7 @@ pub fn parse_read_csv_args(ruby: &Ruby, args: &[Value]) -> Result<ReadCsvArgs, E
 
     let null_string = kwargs.optional.3.unwrap_or_default();
 
-    let buffer_size = kwargs.optional.4.unwrap_or(BUFFER_CHANNEL_SIZE);
+    // let buffer_size = kwargs.optional.4.unwrap_or(BUFFER_CHANNEL_SIZE);
 
     let result_type = match kwargs
         .optional
@@ -172,7 +169,6 @@ pub fn parse_read_csv_args(ruby: &Ruby, args: &[Value]) -> Result<ReadCsvArgs, E
         delimiter,
         quote_char,
         null_string,
-        buffer_size,
         result_type,
         flexible,
         flexible_default,

--- a/ext/osv/src/utils.rs
+++ b/ext/osv/src/utils.rs
@@ -51,7 +51,6 @@ pub fn parse_read_csv_args(ruby: &Ruby, args: &[Value]) -> Result<ReadCsvArgs, E
             Option<String>,
             Option<String>,
             Option<Option<String>>,
-            Option<usize>,
             Option<Value>,
             Option<bool>,
             Option<Option<String>>,
@@ -66,7 +65,6 @@ pub fn parse_read_csv_args(ruby: &Ruby, args: &[Value]) -> Result<ReadCsvArgs, E
             "col_sep",
             "quote_char",
             "nil_string",
-            "buffer_size",
             "result_type",
             "flexible",
             "flexible_default",
@@ -104,11 +102,9 @@ pub fn parse_read_csv_args(ruby: &Ruby, args: &[Value]) -> Result<ReadCsvArgs, E
 
     let null_string = kwargs.optional.3.unwrap_or_default();
 
-    // let buffer_size = kwargs.optional.4.unwrap_or(BUFFER_CHANNEL_SIZE);
-
     let result_type = match kwargs
         .optional
-        .5
+        .4
         .map(|value| parse_string_or_symbol(ruby, value))
     {
         Some(Ok(Some(parsed))) => match parsed.as_str() {
@@ -130,13 +126,13 @@ pub fn parse_read_csv_args(ruby: &Ruby, args: &[Value]) -> Result<ReadCsvArgs, E
         None => String::from("hash"),
     };
 
-    let flexible = kwargs.optional.6.unwrap_or_default();
+    let flexible = kwargs.optional.5.unwrap_or_default();
 
-    let flexible_default = kwargs.optional.7.unwrap_or_default();
+    let flexible_default = kwargs.optional.6.unwrap_or_default();
 
     let trim = match kwargs
         .optional
-        .8
+        .7
         .map(|value| parse_string_or_symbol(ruby, value))
     {
         Some(Ok(Some(parsed))) => match parsed.as_str() {

--- a/lib/osv/version.rb
+++ b/lib/osv/version.rb
@@ -1,3 +1,3 @@
 module OSV
-  VERSION = "0.3.16"
+  VERSION = "0.3.17"
 end


### PR DESCRIPTION
The multi-threaded reader is slower, so get rid of it, and cleanup a bunch of stuff now that the lifetimes and types are cleaner.

```
🏃 Running benchmarks...
Benchmarking with 3000001 lines of data

ruby 3.3.6 (2024-11-05 revision 75015d4c1f) +YJIT [arm64-darwin24]
Warming up --------------------------------------
      CSV - StringIO     1.000 i/100ms
  FastCSV - StringIO     1.000 i/100ms
      OSV - StringIO     1.000 i/100ms
   CSV - Hash output     1.000 i/100ms
   OSV - Hash output     1.000 i/100ms
  CSV - Array output     1.000 i/100ms
  OSV - Array output     1.000 i/100ms
FastCSV - Array output
                         1.000 i/100ms
OSV - Direct Open Array output
                         1.000 i/100ms
       OSV - Gzipped     1.000 i/100ms
OSV - Gzipped Direct     1.000 i/100ms
   FastCSV - Gzipped     1.000 i/100ms
       CSV - Gzipped     1.000 i/100ms
Calculating -------------------------------------
      CSV - StringIO      0.077 (± 0.0%) i/s    (12.98 s/i) -      3.000 in  38.941029s
  FastCSV - StringIO      0.348 (± 0.0%) i/s     (2.87 s/i) -     11.000 in  31.605748s
      OSV - StringIO      0.644 (± 0.0%) i/s     (1.55 s/i) -     20.000 in  31.043226s
   CSV - Hash output      0.059 (± 0.0%) i/s    (17.06 s/i) -      2.000 in  34.120880s
   OSV - Hash output      0.415 (± 0.0%) i/s     (2.41 s/i) -     13.000 in  31.345045s
  CSV - Array output      0.065 (± 0.0%) i/s    (15.47 s/i) -      2.000 in  30.933014s
  OSV - Array output      0.632 (± 0.0%) i/s     (1.58 s/i) -     19.000 in  30.041713s
FastCSV - Array output
                          0.343 (± 0.0%) i/s     (2.91 s/i) -     11.000 in  32.025722s
OSV - Direct Open Array output
                          0.625 (± 0.0%) i/s     (1.60 s/i) -     19.000 in  30.422727s
       OSV - Gzipped      0.499 (± 0.0%) i/s     (2.00 s/i) -     15.000 in  30.072458s
OSV - Gzipped Direct      0.485 (± 0.0%) i/s     (2.06 s/i) -     15.000 in  30.928617s
   FastCSV - Gzipped      0.316 (± 0.0%) i/s     (3.17 s/i) -     10.000 in  31.658340s
       CSV - Gzipped      0.056 (± 0.0%) i/s    (17.99 s/i) -      2.000 in  35.976917s

Comparison:
      OSV - StringIO:        0.6 i/s
  OSV - Array output:        0.6 i/s - 1.02x  slower
OSV - Direct Open Array output:        0.6 i/s - 1.03x  slower
       OSV - Gzipped:        0.5 i/s - 1.29x  slower
OSV - Gzipped Direct:        0.5 i/s - 1.33x  slower
   OSV - Hash output:        0.4 i/s - 1.55x  slower
  FastCSV - StringIO:        0.3 i/s - 1.85x  slower
FastCSV - Array output:        0.3 i/s - 1.88x  slower
   FastCSV - Gzipped:        0.3 i/s - 2.04x  slower
      CSV - StringIO:        0.1 i/s - 8.36x  slower
  CSV - Array output:        0.1 i/s - 9.97x  slower
   CSV - Hash output:        0.1 i/s - 10.99x  slower
       CSV - Gzipped:        0.1 i/s - 11.59x  slower
```